### PR TITLE
Renames the audio emitter `autoPlay` property to `playing`

### DIFF
--- a/src/extensions/OMI_audio_emitter.js
+++ b/src/extensions/OMI_audio_emitter.js
@@ -107,7 +107,7 @@ export class OMIAudioEmitterExtension extends Extension {
         type: audioEmitter._type,
         gain: audioEmitter._gain,
         loop: audioEmitter._loop,
-        autoPlay: audioEmitter._autoPlay,
+        playing: audioEmitter._playing,
         source: sourceIndex,
       };
 
@@ -213,7 +213,7 @@ export class OMIAudioEmitter extends ExtensionProperty {
   _type = "positional";
   _gain = 1;
   _loop = false;
-  _autoPlay = false;
+  _playing = false;
   _coneInnerAngle = Math.PI * 2;
   _coneOuterAngle = Math.PI * 2;
   _coneOuterGain = 0;
@@ -238,7 +238,7 @@ export class OMIAudioEmitter extends ExtensionProperty {
     this._type = other._type;
     this._gain = other._gain;
     this._loop = other._loop;
-    this._autoPlay = other._autoPlay;
+    this._playing = other._playing;
     this._coneInnerAngle = other._coneInnerAngle;
     this._coneOuterAngle = other._coneOuterAngle;
     this._coneOuterGain = other._coneOuterGain;

--- a/src/transforms/hubsToOMI.js
+++ b/src/transforms/hubsToOMI.js
@@ -46,7 +46,7 @@ async function hubsToOMIAudioEmitter(doc, property, hubsComponents) {
   audioSource.setData(data);
   audioEmitter.setSource(audioSource);
   audioEmitter._loop = audio.loop;
-  audioEmitter._autoPlay = audio.autoPlay;
+  audioEmitter._playing = audio.autoPlay;
 
   const audioParams = hubsComponents.getComponent("audio-params");
   audioEmitter._type = audioParams.audioType === "pannernode" ? "positional" : "global";


### PR DESCRIPTION
In https://github.com/omigroup/gltf-extensions/pull/1 the property `autoPlay` was renamed to `playing`. This pr factors the change. 